### PR TITLE
Modify comma-dangle rule in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "no-console": "off",
-    "import/extensions": ["off", "never"]
+    "import/extensions": ["off", "never"],
+    "comma-dangle": ["error", "always", { "functions": "never" }]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,15 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "no-console": "off",
     "import/extensions": ["off", "never"],
-    "comma-dangle": ["error", "always", { "functions": "never" }]
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never",
+        "imports": "always-multiline",
+        "objects": "always-multiline"
+      }
+    ]
   }
 }

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const server = new Hapi.Server({
     },
   },
 });
-server.connection({ port: process.env.PORT || 3000 });
+server.connection({ port: process.env.PORT || 3000, });
 
 // Register the inert plugin
 server.register(Inert, (err) => {
@@ -41,7 +41,7 @@ if (process.env.NODE_ENV === 'production') {
   server.ext('onRequest', (request, reply) => {
     if (request.headers['x-forwarded-proto'] !== 'https') {
       return reply('Forwarding to secure route').redirect(
-        `https://${request.headers.host}${request.path}${request.url.search}`,
+        `https://${request.headers.host}${request.path}${request.url.search}`
       );
     }
     reply.continue();

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const server = new Hapi.Server({
     },
   },
 });
-server.connection({ port: process.env.PORT || 3000, });
+server.connection({ port: process.env.PORT || 3000 });
 
 // Register the inert plugin
 server.register(Inert, (err) => {


### PR DESCRIPTION
#### What is the PR about?
Since node 6.11.x does not support trailing commas in functions, I had to disable the rule in the eslintrc and modify the server.js file to remove Heroku errors.