### PR TITLE
Configure host for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "eslint-plugin-react": "^7.3.0",
     "flow-bin": "^0.54.1",
     "prettier-eslint": "^7.1.0"
+  },
+  "engines": {
+    "node": "8.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const server = new Hapi.Server({
     },
   },
 });
-server.connection({ port: process.env.PORT || 3000, host: 'localhost' });
+server.connection({ port: process.env.PORT || 3000, host: process.env.HOST || 'localhost' });
 
 // Register the inert plugin
 server.register(Inert, (err) => {


### PR DESCRIPTION
#### What the PR is about
I have changed 'localhost' to a conditional with localhost as a default. The Hapi server is to get its host from an environment variable.